### PR TITLE
feat: Added max requests parameter to jobs

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -21,6 +21,8 @@ config:
             - upcoming
             - popular
             - trending
+        # Optional - the maximum number of movies accepted in this job
+        maxRequests: 2
         # Required - the name of the ruleset used to evaluate movies
         ruleset: Ruleset name
 ```
@@ -46,6 +48,8 @@ config:
         plexLibrary: Movies
         # Your minimum personal rating to consider
         minimumRating: 6.9
+        # Optional - the maximum number of movies accepted in this job
+        maxRequests: 2
         ruleset: Ruleset name
 ```
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -39,12 +39,14 @@ export interface PlexSettings {
 export interface DiscoverySettings extends RulesetConsumer {
     cron?: string;
     streams?: string[];
+    maxRequests?: number;
 }
 
 export interface SmartRecommendationsSettings extends RulesetConsumer {
     cron: string;
     plexLibrary: string;
     minimumRating: number;
+    maxRequests?: number;
 }
 
 export interface OnSettingLoadedCallback {

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -7,7 +7,11 @@ import { color, distinctMovies, isFulfilled, isMovie, success } from '@core/lib/
 import PlexApi from '@core/api/plex';
 
 const processMovieResult = async (movies: MovieResult[], overseerr: OverseerrApi, ruleset: Ruleset, dryRun: boolean, maxRequests: number | undefined) => {
-    var numAdded = 0;
+    let numAdded = 0;
+
+    if (maxRequests !== undefined) {
+        logger.info(`Max requests: ${maxRequests}`)
+    }    
     for (const movie of movies) {
         if (movie.mediaInfo && movie.mediaInfo.status !== MediaStatus.UNKNOWN) {
             logger.info(`  Skipping  - "${movie.title}" because it has already been processed`);
@@ -61,10 +65,6 @@ export const discover = async () => {
         }
         const ruleset = getRuleset(settings.ruleset);
         logger.info(`Using ruleset: ${ruleset.name}`);
-
-        if (settings.maxRequests !== undefined) {
-            logger.info(`Max requests: ${settings.maxRequests}`)
-        }
 
         logger.info(` Searching into following streams: ${streams.join(', ')}`);
         const results: Promise<MovieResult[]>[] = streams.map((s) => {

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -34,6 +34,7 @@ const processMovieResult = async (movies: MovieResult[], overseerr: OverseerrApi
                 }
                 numAdded += 1;
                 if (maxRequests !== undefined && numAdded >= maxRequests) {
+                    logger.info(`Maximum requests limit (${maxRequests}) reached. Stopping analyze here...`);
                     break;
                 }
             } else if (ruleResult.result === 'reject') {

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -10,8 +10,8 @@ const processMovieResult = async (movies: MovieResult[], overseerr: OverseerrApi
     let numAdded = 0;
 
     if (maxRequests !== undefined) {
-        logger.info(`Max requests: ${maxRequests}`)
-    }    
+        logger.info(`Max requests: ${maxRequests}`);
+    }
     for (const movie of movies) {
         if (movie.mediaInfo && movie.mediaInfo.status !== MediaStatus.UNKNOWN) {
             logger.info(`  Skipping  - "${movie.title}" because it has already been processed`);


### PR DESCRIPTION
Added a `maxRequests` setting to both the `discover` and `smartRecommendations` jobs to limit the number of requests made during those jobs. 